### PR TITLE
Include existing workspace in tables when shiver starts

### DIFF
--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -106,6 +106,10 @@ class HistogramModel:
         """Set the callback function for workspace changes"""
         self.ads_observers.register_call_back(callback)
 
+    def get_all_valid_workspaces(self):
+        """Get all existing workspaces"""
+        return ((name, filter_ws(name), get_frame(name)) for name in mtd.getObjectNames() if filter_ws(name))
+
 
 class FileLoadingObserver(AlgorithmObserver):
     """Object to handle the execution events of the loading algorithms"""

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -21,6 +21,10 @@ class HistogramPresenter:
 
         self.model.ws_change_call_back(self.ws_changed)
 
+        # initialize tables with workspaces already loaded
+        for name, ws_type, frame in self.model.get_all_valid_workspaces():
+            self.view.add_ws(name, ws_type, frame)
+
     def load_file(self, file_type, filename):
         """Call model to load the filename from the UI file dialog"""
         self.model.load(filename, file_type)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 """pytest config"""
 import pytest
+from mantid.simpleapi import mtd
 from shiver import Shiver
 
-# Need to import new algorithms before mantid.simpleapi
+# Need to import the new algorithms so they are registered with mantid
 import shiver.models.makeslice  # noqa: F401 pylint: disable=unused-import
 
 
@@ -13,3 +14,9 @@ def shiver_app(qtbot):
     qtbot.addWidget(app)
     app.show()
     return app
+
+
+@pytest.fixture(autouse=True)
+def clear_ads():
+    """clear the ADS after every test"""
+    mtd.clear()


### PR DESCRIPTION
Load some valid workspaces in the mantidworkbench before opening Shiver, when you do open shiver the workspaces should now be in the tables where previously they were not.

[1001](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1001)