### PR TITLE
Adding changes to readthedocs.yml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,6 +1,14 @@
+version: 2
+
 build:
   os: ubuntu-22.04
   tools:
     python: "mambaforge-4.10"
+
 sphinx:
   builder: html
+  configuration: docs/source/conf.py
+  fail_on_warning: true
+
+conda:
+  environment: environment.yml


### PR DESCRIPTION
This includes additions to the `readthedocs.yml` file. These changes will hopefully fix the issues with readthedocs deploy. The main issue being an import on their machines missing. "versioningit" is not a module

This readthedocs.yml modification is taken from SNAPRed. **The version declaration on the top of the file may not be needed.**