### PR TITLE
Allow adding additional data to pre-selected dataset

### DIFF
--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -177,7 +177,11 @@ class Generate(QWidget):
     def set_dataset_to_custom(self):
         """Set the dataset in the oncat widget to "custom"."""
         if not self.inhibit_update:
-            self.oncat_widget.set_dataset_to_custom()
+            self.oncat_widget.dataset.blockSignals(True)
+            try:
+                self.oncat_widget.set_dataset_to_custom()
+            finally:
+                self.oncat_widget.dataset.blockSignals(False)
 
     def _update_title(self, mde_name: str):
         """Update the title of the widget to include the MDE name"""

--- a/src/shiver/views/reduction_parameters.py
+++ b/src/shiver/views/reduction_parameters.py
@@ -204,11 +204,14 @@ class ReductionParameters(QGroupBox):
         """Open the dialog to set advanced options"""
         dialog = AdvancedDialog(self)
         self.active_dialog = dialog
+        goniometer = ""
         # populate the dialog
         if self.dict_advanced:
+            goniometer = self.dict_advanced["Goniometer"]
             dialog.populate_advanced_options_from_dict(self.dict_advanced)
         dialog.exec_()
-        self.advanced_apply_callback(self.dict_advanced)
+        if self.dict_advanced["Goniometer"] != goniometer:
+            self.advanced_apply_callback(self.dict_advanced)
         self.active_dialog = None
 
     def set_pol_btn(self):


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
Previously, once user pre-selects a dataset, control + click on additional raw data would reset the highlighted data. This pr preserves previous selection.

Additionally, it automatically fixed an issue where "advanced" option tab would wipe the selected raw data list when the dataset is in "custom" mode.

Video below shows the correct behavior.

[Screencast from 2026-01-14 13-37-23.webm](https://github.com/user-attachments/assets/18cd2863-8a40-46d4-bbbb-ae37e3264f57)

<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
