### PR TITLE
Fix bug for empty dictionary case

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -12,8 +12,6 @@ environments:
     - url: https://prefix.dev/pixi-build-backends/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -5958,9 +5956,10 @@ packages:
   timestamp: 1762858315311
 - pypi: ./
   name: shiver
-  version: 1.8.3rc1
+  version: 1.8.4
   sha256: ed0b229d85845d422a39d6f4d4b909f68136d05bc03e42049d57cd4fffae3585
   requires_python: '>=3.10'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/linux-64/sip-6.7.12-py311hb755f60_0.conda
   sha256: 71a0ee22522b232bf50d4d03d012e53cd5d1251d09dffc1c72d7c33a1086fe6f
   md5: 02336abab4cb5dd794010ef53c54bd09

--- a/src/shiver/views/reduction_parameters.py
+++ b/src/shiver/views/reduction_parameters.py
@@ -210,7 +210,7 @@ class ReductionParameters(QGroupBox):
             goniometer = self.dict_advanced["Goniometer"]
             dialog.populate_advanced_options_from_dict(self.dict_advanced)
         dialog.exec_()
-        if self.dict_advanced["Goniometer"] != goniometer:
+        if self.dict_advanced and self.dict_advanced["Goniometer"] != goniometer:
             self.advanced_apply_callback(self.dict_advanced)
         self.active_dialog = None
 


### PR DESCRIPTION
# Short description of the changes:
When opening advanced dialog for the first time and cancelling, one gets an emty dictionary. Getting goniometer out of it will cause a crash

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
