### PR TITLE
Allow PercentMin and PercentMax to be floating point numbers

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
-          pixi-version: v0.62.2
+          pixi-version: v0.70.2
           manifest-path: pyproject.toml
           # Workaround: Dynamic versioning (versioningit) causes lock file version mismatch.
           # We skip the editable package install and do it separately with pip.
@@ -114,7 +114,7 @@ jobs:
       - name: Setup Pixi
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
-          pixi-version: v0.62.2
+          pixi-version: v0.70.2
           manifest-path: pyproject.toml
           # Workaround: Dynamic versioning (versioningit) causes lock file version mismatch.
           # We skip the editable package install and do it separately with pip.

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup pixi
         uses: prefix-dev/setup-pixi@v0.9.6
         with:
-          pixi-version: v0.62.2
+          pixi-version: v0.70.2
           manifest-path: pyproject.toml
           # Workaround: Dynamic versioning (versioningit) causes lock file version mismatch.
           # We skip the editable package install and do it separately with pip.

--- a/src/shiver/models/generate_dgs_mde.py
+++ b/src/shiver/models/generate_dgs_mde.py
@@ -175,13 +175,13 @@ class GenerateDGSMDE(PythonAlgorithm):
 
         self.declareProperty(
             name="PercentMin",
-            defaultValue=0.,
+            defaultValue=0.0,
             doc="Minimum percentage",
         )
 
         self.declareProperty(
             name="PercentMax",
-            defaultValue=20.,
+            defaultValue=20.0,
             doc="Maximum percentage",
         )
 

--- a/src/shiver/models/generate_dgs_mde.py
+++ b/src/shiver/models/generate_dgs_mde.py
@@ -175,13 +175,13 @@ class GenerateDGSMDE(PythonAlgorithm):
 
         self.declareProperty(
             name="PercentMin",
-            defaultValue=0,
+            defaultValue=0.,
             doc="Minimum percentage",
         )
 
         self.declareProperty(
             name="PercentMax",
-            defaultValue=20,
+            defaultValue=20.,
             doc="Maximum percentage",
         )
 

--- a/tests/models/test_generatemde.py
+++ b/tests/models/test_generatemde.py
@@ -592,8 +592,8 @@ def test_generate_dgs_mde_bkg_minimized():
         bkg_md = GenerateDGSMDE(
             Filenames=",".join(os.path.join(raw_data_folder, data_file) for data_file in data_files),
             Type="Background (minimized by angle and energy)",
-            PercentMin=0.,
-            PercentMax=20.,
+            PercentMin=0.0,
+            PercentMax=20.0,
         )
 
     assert "A grouping file is required when for 'Background (minimized by angle and energy)'" in str(excinfo.value)

--- a/tests/models/test_generatemde.py
+++ b/tests/models/test_generatemde.py
@@ -592,6 +592,8 @@ def test_generate_dgs_mde_bkg_minimized():
         bkg_md = GenerateDGSMDE(
             Filenames=",".join(os.path.join(raw_data_folder, data_file) for data_file in data_files),
             Type="Background (minimized by angle and energy)",
+            PercentMin=0.,
+            PercentMax=20.,
         )
 
     assert "A grouping file is required when for 'Background (minimized by angle and energy)'" in str(excinfo.value)


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
