### PR TITLE
Fix Shiver to work with PyQt6

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -84,14 +84,21 @@ jobs:
           mkdir -p /tmp/local-channel/linux-64
           cp *.conda /tmp/local-channel/linux-64
 
+      - name: Install conda package
+        id: install
+        uses: neutrons/conda-actions/pkg-install@v2
+        with:
+          package-name: ${{ env.PKG_NAME }}
+          local-channel: /tmp/local-channel
+          extra-channels: mantid-ornl oncat neutrons
+          python-version: "3.11"
+
       - name: Verify conda package
         uses: neutrons/conda-actions/pkg-verify@v2
         with:
           package-name: ${{ env.PKG_NAME }}
           module-name: ${{ env.MODULE_NAME }}
-          local-channel: /tmp/local-channel
-          extra-channels: mantid-ornl oncat neutrons
-          python-version: "3.11"
+          conda-env-name: ${{ steps.install.outputs.conda_env }}
 
       - name: Upload conda package as artifact
         uses: actions/upload-artifact@v7

--- a/src/shiver/__init__.py
+++ b/src/shiver/__init__.py
@@ -7,6 +7,6 @@ from .version import __version__  # noqa: F401
 
 def Shiver():  # pylint: disable=invalid-name
     """This is needed for backward compatibility because mantid workbench does "from shiver import Shiver" """
-    from .shiver import Shiver as shiver  # pylint: disable=import-outside-toplevel
+    from .shiver import get_instance  # pylint: disable=import-outside-toplevel
 
-    return shiver()
+    return get_instance()

--- a/src/shiver/shiver.py
+++ b/src/shiver/shiver.py
@@ -30,13 +30,6 @@ logger = Logger("SHIVER")
 class Shiver(QMainWindow):
     """Main Shiver window"""
 
-    __instance = None
-
-    def __new__(cls):
-        if Shiver.__instance is None:
-            Shiver.__instance = QMainWindow.__new__(cls)  # pylint: disable=no-value-for-parameter
-        return Shiver.__instance
-
     def __init__(self, parent=None):
         super().__init__(parent)
         logger.information(f"Shiver version: {__version__}")
@@ -56,6 +49,21 @@ class Shiver(QMainWindow):
         self.setCentralWidget(self.main_window)
 
 
+__instance = None
+
+
+def get_instance():
+    """Return the single Shiver window, creating it on first call.
+
+    The single-instance logic lives here, at module level, rather than in a
+    ``Shiver.__new__`` otherwise it segfaults under PyQt6.
+    """
+    global __instance  # pylint: disable=global-statement
+    if __instance is None:
+        __instance = Shiver()
+    return __instance
+
+
 def gui():
     """
     Main entry point for Qt application
@@ -66,6 +74,6 @@ def gui():
         sys.exit()
     else:
         app = QApplication(sys.argv)
-        window = Shiver()
+        window = get_instance()
         window.show()
         sys.exit(app.exec_())

--- a/src/shiver/views/histogram_parameters.py
+++ b/src/shiver/views/histogram_parameters.py
@@ -386,8 +386,11 @@ class HistogramParameter(QGroupBox):
             dim_name = ref_dict[combo_dim.currentText()]
             dim_min = combo_min.text()
             dim_max = combo_max.text()
-            # if step visible, then it is a binning parameter
-            if combo_step.isVisible():
+            # if step visible, then it is a binning parameter.
+            # Use isHidden() rather than isVisible(): isVisible() also returns
+            # False whenever the window is not on screen, which
+            # makes tests fail in PyQt6.
+            if not combo_step.isHidden():
                 dim_step = combo_step.text()
             else:
                 dim_step = ""


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->

I had to change the way we did the singleton initialization otherwise `__init__` was being called multiple times on the same instance which caused segfaults in PyQt6.

Also change the check for `isVisible` in `gather_histogram_parameters` which in `PyQt6` would return `False` when the window was off the screen making some tests fail.

Mantid has yet to move to `Qt6` by default yet (see mantidproject/mantid#41652) but you can test it with packages from the `mantid-test/label/qt6` channel.

Make this change to `pyproject.toml` to test with the Qt6 Mantid.

```diff
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,7 @@ preview = ["pixi-build"] # Need this to access pixi-build feature
 platforms = ["linux-64"]
 channels = [
     "conda-forge",
-    "mantid-ornl",
-    "mantid-ornl/label/rc",
-    "mantid",
+    "mantid-test/label/qt6",
     "oncat",
     "neutrons",
     "neutrons/label/rc",
@@ -94,13 +92,13 @@ versioningit = "*"
 
 [tool.pixi.package.run-dependencies]
 #dependencies for the conda package - for shiver to run
-mantidworkbench = "==6.15.0.1"
+mantidworkbench = "*"
 pyoncatqt = ">=1.2.1"
 configupdater = "*"
 
 [tool.pixi.dependencies]
 # Conda package dependencies for the local environment though pixi
-mantidworkbench = "==6.15.0.1"
+mantidworkbench = "*"
 pyoncatqt = ">=1.2.1"
 configupdater = "*"
```

Make sure the tests pass under `Qt6` and that shiver still launches from mantid workbench.

Ref: [13014: Update shiver to mantid v7.0](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/13014)

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
