### PR TITLE
Add option to manually select/deselect files by run number

### DIFF
--- a/src/shiver/views/data.py
+++ b/src/shiver/views/data.py
@@ -2,6 +2,7 @@
 
 import glob
 import os
+import re
 
 from qtpy.QtWidgets import (
     QAbstractItemView,
@@ -16,7 +17,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from .invalid_styles import INVALID_QLISTWIDGET
+from .invalid_styles import INVALID_QLINEEDIT, INVALID_QLISTWIDGET
 
 
 class RawData(QGroupBox):
@@ -48,9 +49,28 @@ class RawData(QGroupBox):
         self.files.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.files.setSortingEnabled(True)
 
+        self.manual_selection = QLineEdit()
+        self.manual_selection.setToolTip(
+            "Select runs by number pattern, e.g. '1-3, 5:20:3' selects runs 1,2,3,5,8,11,14,17,20."
+        )
+        manual_layout = QHBoxLayout()
+        manual_layout.addWidget(QLabel("Manual selection"))
+        manual_layout.addWidget(self.manual_selection)
+        self.manual_select = QPushButton("Select")
+        self.manual_select.setEnabled(False)
+        self.manual_select.clicked.connect(self._manual_selection_apply)
+        manual_layout.addWidget(self.manual_select)
+        self.manual_deselect = QPushButton("Deselect")
+        self.manual_deselect.setEnabled(False)
+        self.manual_deselect.clicked.connect(self._manual_selection_deselect)
+        manual_layout.addWidget(self.manual_deselect)
+        manual_selection_widget = QWidget()
+        manual_selection_widget.setLayout(manual_layout)
+
         layout = QVBoxLayout()
         layout.addWidget(path_line)
         layout.addWidget(self.files)
+        layout.addWidget(manual_selection_widget)
         self.setLayout(layout)
 
         self.selected_list_from_oncat = None
@@ -58,6 +78,7 @@ class RawData(QGroupBox):
         # mandatory field check its state
         # at least one item should be selected
         self.files.itemSelectionChanged.connect(self.check_file_input)
+        self.manual_selection.textChanged.connect(self._on_manual_selection_changed)
 
     def _path_edited(self):
         if self.path.text() != self.directory:
@@ -101,6 +122,46 @@ class RawData(QGroupBox):
         else:
             self.set_field_invalid_state(self.files)
         return state
+
+    def _on_manual_selection_changed(self):
+        text = self.manual_selection.text().strip()
+        if not text:
+            self.manual_select.setEnabled(False)
+            self.manual_deselect.setEnabled(False)
+            self.manual_selection.setStyleSheet("")
+            return
+        valid, _ = parse_run_numbers(text)
+        self.manual_select.setEnabled(valid)
+        self.manual_deselect.setEnabled(valid)
+        if valid:
+            self.manual_selection.setStyleSheet("")
+        else:
+            self.manual_selection.setStyleSheet(INVALID_QLINEEDIT)
+
+    def _manual_selection_apply(self):
+        text = self.manual_selection.text().strip()
+        valid, run_numbers = parse_run_numbers(text)
+        if not valid:
+            return
+        run_set = set(run_numbers)
+        self.files.clearSelection()
+        for i in range(self.files.count()):
+            item = self.files.item(i)
+            run_number = _extract_run_number(item.text())
+            if run_number is not None and run_number in run_set:
+                item.setSelected(True)
+
+    def _manual_selection_deselect(self):
+        text = self.manual_selection.text().strip()
+        valid, run_numbers = parse_run_numbers(text)
+        if not valid:
+            return
+        run_set = set(run_numbers)
+        for i in range(self.files.count()):
+            item = self.files.item(i)
+            run_number = _extract_run_number(item.text())
+            if run_number is not None and run_number in run_set:
+                item.setSelected(False)
 
     def get_selected(self, use_grouped=False):
         """Return a list of the full path of the files selected"""
@@ -169,6 +230,56 @@ class RawData(QGroupBox):
 
         # set the selection
         self.set_selected(filename_list_flattened)
+
+
+def _extract_run_number(filename):
+    """Return the integer run number from a filename like INST_12345.nxs.h5, or None.
+
+    Strips all extensions first (e.g. .nxs.h5), then returns the last underscore-
+    delimited digit group, which is the run number in names like INST_12345 or
+    INST_12345_event.
+    """
+    stem = filename
+    while "." in stem:
+        stem = stem.rsplit(".", 1)[0]
+    matches = re.findall(r"_(\d+)", stem)
+    return int(matches[-1]) if matches else None
+
+
+def parse_run_numbers(text):
+    """Parse a run-number pattern string.
+
+    Supports single numbers, dash ranges (1-3), colon ranges with optional step
+    (1:10:2), and comma-separated combinations.
+
+    Returns (is_valid: bool, run_numbers: list[int]).
+    """
+    try:
+        result = []
+        for token in text.split(","):
+            token = token.strip()
+            if not token:
+                continue
+            if ":" in token:
+                parts = [int(p) for p in token.split(":")]
+                if len(parts) == 2:
+                    result.extend(range(parts[0], parts[1] + 1))
+                elif len(parts) == 3:
+                    result.extend(range(parts[0], parts[1] + 1, parts[2]))
+                else:
+                    return False, []
+            elif "-" in token:
+                parts = [int(p) for p in token.split("-")]
+                if len(parts) != 2:
+                    return False, []
+                result.extend(range(parts[0], parts[1] + 1))
+            else:
+                result.append(int(token))
+        if not result:
+            return False, []
+        return True, result
+    except (ValueError, TypeError):
+        return False, []
 
 
 def filename_str_to_list(filenames_str):

--- a/tests/views/test_raw_data.py
+++ b/tests/views/test_raw_data.py
@@ -233,7 +233,7 @@ def test_manual_selection_deselect(qtbot):
     qtbot.addWidget(raw_data)
 
     directory = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/raw"))
-    # Pre-select runs 178921-178924
+    # Preselect runs 178921-178924
     raw_data.set_selected([os.path.join(directory, f"HYS_{r}.nxs.h5") for r in range(178921, 178925)])
 
     # Deselect 178922 and 178923, leaving 178921 and 178924 selected

--- a/tests/views/test_raw_data.py
+++ b/tests/views/test_raw_data.py
@@ -234,9 +234,7 @@ def test_manual_selection_deselect(qtbot):
 
     directory = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/raw"))
     # Pre-select runs 178921-178924
-    raw_data.set_selected(
-        [os.path.join(directory, f"HYS_{r}.nxs.h5") for r in range(178921, 178925)]
-    )
+    raw_data.set_selected([os.path.join(directory, f"HYS_{r}.nxs.h5") for r in range(178921, 178925)])
 
     # Deselect 178922 and 178923, leaving 178921 and 178924 selected
     raw_data.manual_selection.setText("178922-178923")

--- a/tests/views/test_raw_data.py
+++ b/tests/views/test_raw_data.py
@@ -5,7 +5,7 @@ import os
 import pytest
 from qtpy import QtCore, QtWidgets
 
-from shiver.views.data import RawData, filename_str_to_list
+from shiver.views.data import RawData, _extract_run_number, filename_str_to_list, parse_run_numbers
 
 
 def test_raw_data_get_selection(qtbot):
@@ -173,6 +173,76 @@ def test_populate_data_widget_from_dict(monkeypatch, qtbot):
     # case 4: mixed
     data_widget.populate_from_dict({"filename": "file1, file2+file3"})
     assert selected_list == ["file1", "file2", "file3"]
+
+
+def test_extract_run_number():
+    """Test run number extraction from filenames."""
+    assert _extract_run_number("HYS_178922.nxs.h5") == 178922
+    assert _extract_run_number("SEQ_124735.nxs.h5") == 124735
+    assert _extract_run_number("INST_12345_event.nxs") == 12345
+    assert _extract_run_number("no_number.nxs.h5") is None
+
+
+def test_parse_run_numbers():
+    """Test run number pattern parsing via IntArrayProperty."""
+    ok, nums = parse_run_numbers("1-3, 5:20:3")
+    assert ok
+    assert nums == [1, 2, 3, 5, 8, 11, 14, 17, 20]
+
+    ok, nums = parse_run_numbers("178922, 178924")
+    assert ok
+    assert nums == [178922, 178924]
+
+    ok, nums = parse_run_numbers("bad string !!")
+    assert not ok
+    assert nums == []
+
+
+def test_manual_selection_select(qtbot):
+    """Test that the Select button enables on valid patterns and selects matching files."""
+    raw_data = RawData()
+    qtbot.addWidget(raw_data)
+
+    directory = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/raw"))
+    raw_data._update_file_list(directory)
+
+    # Buttons disabled when field is empty
+    assert not raw_data.manual_select.isEnabled()
+    assert not raw_data.manual_deselect.isEnabled()
+
+    # Buttons disabled on invalid pattern
+    qtbot.keyClicks(raw_data.manual_selection, "!!!bad")
+    assert not raw_data.manual_select.isEnabled()
+    assert not raw_data.manual_deselect.isEnabled()
+
+    # Buttons enabled on valid pattern
+    raw_data.manual_selection.clear()
+    qtbot.keyClicks(raw_data.manual_selection, "178922-178924")
+    assert raw_data.manual_select.isEnabled()
+    assert raw_data.manual_deselect.isEnabled()
+
+    # Clicking Select selects only the matching files
+    raw_data.manual_select.click()
+    selected = sorted(item.text() for item in raw_data.files.selectedItems())
+    assert selected == ["HYS_178922.nxs.h5", "HYS_178923.nxs.h5", "HYS_178924.nxs.h5"]
+
+
+def test_manual_selection_deselect(qtbot):
+    """Test that the Deselect button removes matching files from the current selection."""
+    raw_data = RawData()
+    qtbot.addWidget(raw_data)
+
+    directory = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/raw"))
+    # Pre-select runs 178921-178924
+    raw_data.set_selected(
+        [os.path.join(directory, f"HYS_{r}.nxs.h5") for r in range(178921, 178925)]
+    )
+
+    # Deselect 178922 and 178923, leaving 178921 and 178924 selected
+    raw_data.manual_selection.setText("178922-178923")
+    raw_data.manual_deselect.click()
+    selected = sorted(item.text() for item in raw_data.files.selectedItems())
+    assert selected == ["HYS_178921.nxs.h5", "HYS_178924.nxs.h5"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Short description of the changes:
In generating MDEs tab one can now select/deselect runs programmatically, e.g. '1-3, 5:20:3' selects runs 1,2,3,5,8,11,14,17,20.

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
