### PR TITLE
Warn users about missing normalization

### DIFF
--- a/src/shiver/models/generate.py
+++ b/src/shiver/models/generate.py
@@ -11,7 +11,7 @@ from mantid.kernel import (  # pylint: disable=no-name-in-module
     Logger,
     Property,
 )
-from mantid.simpleapi import AddSampleLog, mtd  # pylint: disable=no-name-in-module
+from mantid.simpleapi import mtd  # pylint: disable=no-name-in-module
 
 logger = Logger("SHIVER")
 
@@ -207,19 +207,17 @@ class GenerateModel:
                 self.error_callback(msg=err_msg)
         else:
             logger.information("GenerateDGSMDE finished")
-
             # attach config_dict to the workspace
             save_mde_config_dict(self.workspace_name, self.config_dict)
-
             # save polarization sample logs separately
             workspace = mtd[self.workspace_name]
             if self.config_dict["PolarizedOptions"]:
                 for field, value in self.config_dict["PolarizedOptions"].items():
                     if field != "PSDA":
-                        AddSampleLog(workspace, LogName=field, LogText=value, LogType="String")
+                        workspace.getExperimentInfo(0).mutableRun().addProperty(field, str(value), True)
                     else:
                         # psda is saved as a small character name
-                        AddSampleLog(workspace, LogName="psda", LogText=value, LogType="String")
+                        workspace.getExperimentInfo(0).mutableRun().addProperty("psda", str(value), True)
 
             # kick off the saving of the output to disk
             self.save_mde_to_disk()

--- a/src/shiver/models/generate_dgs_mde.py
+++ b/src/shiver/models/generate_dgs_mde.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=no-name-in-module
 import json
+from pathlib import Path
 
 import numpy
 from mantid.api import (
@@ -23,6 +24,7 @@ from mantid.kernel import (
     amend_config,
 )
 from mantid.simpleapi import (
+    CloneWorkspace,
     Comment,
     ConvertDGSToSingleMDE,
     CreateWorkspace,
@@ -258,6 +260,10 @@ class GenerateDGSMDE(PythonAlgorithm):
         __mask = None
         if norm_filename:
             __mask = LoadNexusProcessed(Filename=norm_filename)
+            # create a clone of the normaliation workspace if not already exists
+            norm_name = Path(norm_filename).stem
+            if not mtd.doesExist(norm_name):
+                CloneWorkspace(InputWorkspace=__mask, OutputWorkspace=norm_name)
 
         mask_filename = self.getPropertyValue("MaskFilename")
         if mask_filename:

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -3,7 +3,7 @@
 # pylint: disable=invalid-name
 import os
 
-from qtpy.QtWidgets import QWidget
+from qtpy.QtWidgets import QMessageBox, QWidget
 
 from shiver.models.corrections import CorrectionsModel, get_ions_list
 from shiver.models.generate import GenerateModel, gather_mde_config_dict, save_mde_config_dict
@@ -63,6 +63,9 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
 
         # connect for populating UI when a histogram workspace is selected
         self.view.histogram_workspaces.histogram_selected_signal.connect(self.populate_ui_from_selected_histogram)
+
+        # ignore normalization warning for the rest of the session, if user chooses to ignore it
+        self.ignore_normalization_warning = False
 
     def load_file(self, file_type, filename):
         """Call model to load the filename from the UI file dialog"""
@@ -436,6 +439,20 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
             # gather the parameters from the view for MakeSlice
             config = self.build_config_for_make_slice()
 
+            # check if normalization workspace is used
+            norm_in_mde = gather_mde_config_dict(config.get("InputWorkspace", "")).get("NormalizationDataFile", "")
+            if not self.ignore_normalization_warning and norm_in_mde and config.get("NormalizationWorkspace", "") == "":
+                result = QMessageBox.question(
+                    self.view,
+                    "Normalization workspace",
+                    "A normalization workspace is not selected, even though the MDE contains normalization data.\nDo you want to continue?\nChoosing ignore will stop this message from appearing for the rest of the session.",
+                    QMessageBox.Yes | QMessageBox.No | QMessageBox.Ignore,
+                )
+                if result == QMessageBox.Ignore:
+                    self.ignore_normalization_warning = True
+                elif result == QMessageBox.No:
+                    self.view.disable_while_running(False)
+                    return
             # send to model for processing
             self.model.do_make_slice(config)
 

--- a/tests/views/test_histogram.py
+++ b/tests/views/test_histogram.py
@@ -9,6 +9,7 @@ import pytest
 import shiver.shiver  # noqa: F401 isort: skip #must be imported before mantid
 from mantid.simpleapi import (  # pylint: disable=no-name-in-module, wrong-import-order
     CreateSampleWorkspace,
+    Load,
     LoadMD,
     MakeSFCorrectedSlices,
     MakeSlice,
@@ -197,7 +198,7 @@ def test_norm_workspaces_menu(qtbot):
     assert rename[0] == ("norm1", "new_ws_name")
 
 
-def test_make_histogram_button(shiver_app, qtbot):
+def test_make_histogram_button(shiver_app, qtbot, monkeypatch):
     """Test the make histogram button."""
     shiver = shiver_app
     histogram = shiver.main_window.histogram
@@ -220,19 +221,24 @@ def test_make_histogram_button(shiver_app, qtbot):
     mtd.clear()
     histogram_presenter.submit_histogram_to_make_slice()
     assert norm_list.count() == 0
+    assert histogram_presenter.ignore_normalization_warning is False
 
     # Case 1: happy path
     LoadMD(
-        Filename=os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "../data/mde/merged_mde_MnO_25meV_5K_unpol_178921-178926.nxs"
-        ),
+        Filename=os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/mde/px_mini_NSF.nxs"),
         OutputWorkspace="data",
+    )
+    Load(
+        Filename=os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/normalization/TiZr.nxs"),
+        OutputWorkspace="TiZr",
     )
     qtbot.wait(200)
     # make sure the workspace is in the list
     assert mde_list.count() == 1
-    # set data and background
+    assert norm_list.count() == 1
+    # set data and normalization
     mde_list.set_data("data", "UNP")
+    norm_list.set_selected("TiZr")
     # configure the histogram parameters widget
     qtbot.mouseClick(histogram_parameters.cut_1d, Qt.LeftButton)
     histogram_parameters.name.clear()
@@ -248,7 +254,10 @@ def test_make_histogram_button(shiver_app, qtbot):
     histogram_parameters.smoothing.clear()
     qtbot.keyClicks(histogram_parameters.smoothing, "3.45")
     assert len(histogram.field_errors) == 0
+
+    # do the histogram
     qtbot.mouseClick(histogram_parameters.histogram_btn, Qt.LeftButton)
+
     # check that widgets are disabled
     assert not histogram_parameters.isEnabled()
     assert not mde_list.isEnabled()
@@ -263,6 +272,66 @@ def test_make_histogram_button(shiver_app, qtbot):
     assert histogram_parameters.isEnabled()
     assert mde_list.isEnabled()
     assert norm_list.isEnabled()
+
+    # Case 2: try again, with missing normalization
+    histogram_parameters.name.clear()
+    qtbot.keyClicks(histogram_parameters.name, "output1")
+    norm_list.clearSelection()
+    monkeypatch.setattr(QMessageBox, "question", lambda *args: QMessageBox.No)
+
+    # skip the histogram
+    qtbot.mouseClick(histogram_parameters.histogram_btn, Qt.LeftButton)
+
+    # check that output is in the histogram list
+    qtbot.wait(500)
+    assert histogram_workspaces.count() == 1
+
+    # check that widgets are re-enabled
+    assert histogram_parameters.isEnabled()
+    assert mde_list.isEnabled()
+    assert norm_list.isEnabled()
+
+    monkeypatch.setattr(QMessageBox, "question", lambda *args: QMessageBox.Yes)
+
+    # Case 3: do the histogram
+    qtbot.mouseClick(histogram_parameters.histogram_btn, Qt.LeftButton)
+
+    # check that widgets are disabled
+    assert not histogram_parameters.isEnabled()
+    assert not mde_list.isEnabled()
+    assert not norm_list.isEnabled()
+
+    # check that output is in the histogram list
+    qtbot.wait(500)
+    assert histogram_workspaces.count() == 2
+    assert histogram_workspaces.item(1).text() == "output1"
+
+    # check that widgets are re-enabled
+    assert histogram_parameters.isEnabled()
+    assert mde_list.isEnabled()
+    assert norm_list.isEnabled()
+    assert histogram_presenter.ignore_normalization_warning is False
+
+    monkeypatch.setattr(QMessageBox, "question", lambda *args: QMessageBox.Ignore)
+
+    # Case 4: do the histogram after clicking the ignore normalization warning
+    qtbot.mouseClick(histogram_parameters.histogram_btn, Qt.LeftButton)
+
+    # check that widgets are disabled
+    assert not histogram_parameters.isEnabled()
+    assert not mde_list.isEnabled()
+    assert not norm_list.isEnabled()
+
+    # check that output is in the histogram list
+    qtbot.wait(500)
+    assert histogram_workspaces.count() == 2
+    assert histogram_workspaces.item(1).text() == "output1"
+
+    # check that widgets are re-enabled
+    assert histogram_parameters.isEnabled()
+    assert mde_list.isEnabled()
+    assert norm_list.isEnabled()
+    assert histogram_presenter.ignore_normalization_warning is True
 
 
 def test_populate_ui_from_history_dict(shiver_app):


### PR DESCRIPTION
# Short description of the changes:
Warn users if the MDE they selected has a normalization file, but they don't use it in histogramming

# Long description of the changes:
To test:
1. Load "merged_mde..." (no normalization in the history) and "px_mini.." (has normalization) MDEs
2. Lod the TiZr from normalization
3. Uncheck the "Manual" in the histogram name
4. Select just "merged", and do a histogram (for me I did a 1D in energy, step of 1) - no message
5. Select "px_mini" and the "TiZr" normalization - no message
6. Unselect "TiZr" (ctrl-click). You get a question - if no, no new histogram. if yes - new histogram
7. Do the histogramming again, but this time choose ignore. Clicking on histogram again will not bring back the message box until you restart Shiver



# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
